### PR TITLE
Fix display showcases

### DIFF
--- a/ckanext/showcase/logic/action/get.py
+++ b/ckanext/showcase/logic/action/get.py
@@ -124,7 +124,6 @@ def package_showcase_list(context, data_dict):
                 )
                 showcase_list.append(showcase)
             except NotAuthorized:
-                traceback.print_exc()
                 log.error('Not authorized to access Package with ID: '
                           + str(showcase_id))
 

--- a/ckanext/showcase/logic/action/get.py
+++ b/ckanext/showcase/logic/action/get.py
@@ -2,6 +2,7 @@ import sqlalchemy
 
 import ckan.plugins.toolkit as toolkit
 import ckan.lib.dictization.model_dictize as model_dictize
+from ckan.logic import NotAuthorized
 from ckan.lib.navl.dictization_functions import validate
 
 from ckanext.showcase.logic.schema import (showcase_package_list_schema,
@@ -78,9 +79,12 @@ def showcase_package_list(context, data_dict):
         # for each package id, get the package dict and append to list if
         # active
         for pkg_id in pkg_id_list:
-            pkg = toolkit.get_action('package_show')(context, {'id': pkg_id})
-            if pkg['state'] == 'active':
-                pkg_list.append(pkg)
+            try:
+                pkg = toolkit.get_action('package_show')(context, {'id': pkg_id})
+                if pkg['state'] == 'active':
+                    pkg_list.append(pkg)
+            except NotAuthorized:
+                log.error('Not authorized to access Package with ID: ' + str(pkg_id))
 
     return pkg_list
 

--- a/ckanext/showcase/logic/action/get.py
+++ b/ckanext/showcase/logic/action/get.py
@@ -117,9 +117,16 @@ def package_showcase_list(context, data_dict):
     showcase_list = []
     if showcase_id_list is not None:
         for showcase_id in showcase_id_list:
-            showcase = toolkit.get_action('package_show')(context,
-                                                          {'id': showcase_id})
-            showcase_list.append(showcase)
+            try:
+                showcase = toolkit.get_action('package_show')(
+                    context,
+                    {'id': showcase_id}
+                )
+                showcase_list.append(showcase)
+            except NotAuthorized:
+                traceback.print_exc()
+                log.error('Not authorized to access Package with ID: '
+                          + str(showcase_id))
 
     return showcase_list
 

--- a/ckanext/showcase/logic/action/get.py
+++ b/ckanext/showcase/logic/action/get.py
@@ -2,8 +2,8 @@ import sqlalchemy
 
 import ckan.plugins.toolkit as toolkit
 import ckan.lib.dictization.model_dictize as model_dictize
-from ckan.logic import NotAuthorized
 from ckan.lib.navl.dictization_functions import validate
+from ckan.logic import NotAuthorized
 
 from ckanext.showcase.logic.schema import (showcase_package_list_schema,
                                            package_showcase_list_schema)
@@ -80,12 +80,13 @@ def showcase_package_list(context, data_dict):
         # active
         for pkg_id in pkg_id_list:
             try:
-                pkg = toolkit.get_action('package_show')(context, {'id': pkg_id})
+                pkg = toolkit.get_action('package_show')(context,
+                                                         {'id': pkg_id})
                 if pkg['state'] == 'active':
                     pkg_list.append(pkg)
             except NotAuthorized:
-                log.error('Not authorized to access Package with ID: ' + str(pkg_id))
-
+                log.error(
+                    'Not authorized to access Package with ID: ' + str(pkg_id))
     return pkg_list
 
 


### PR DESCRIPTION
The Showcase-List-View can not be displayed when one of the showcases has an association to a package, that the User can't access (e.g. package was deleted, therefore unauthorized User is not allowed to access said package)

A similar behaviour occured when a User wants to look at associated showcases on the dataset-detail-view. If one of the showcases has an association with a package, they are not authorized to see, the page can not be displayed due to an NotAuthorized-Error.

This bugfix catches that exception and prevents showcases, that can not be displayed to be added to the view. 

IMPORTANT: This prevents the page from breaking when a user looks at either the showcase-list-view or at all associated showcases of a package. That also means, that a showcase won't be shown as association or listed when it has any association with a package the user can't access.
